### PR TITLE
vector-0.11.0 binary

### DIFF
--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,7 +2,7 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/timberio/vector/releases/28880199
+      url: https://api.github.com/repos/timberio/vector/releases/34668611
     path: .
   path: src/vector
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -9,7 +9,7 @@ directories:
         githubRelease:
           # https://github.com/timberio/vector
           slug: timberio/vector
-          tag: v0.10.0
+          tag: v0.11.0
           disableAutoChecksumValidation: true
         includePaths:
-          - vector-x86_64-unknown-linux-musl.tar.gz
+          - vector-*-x86_64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
closes https://github.com/aegershman/vector-boshrelease/issues/13

Note, we go from not having the binary name in the release download to having it in the name